### PR TITLE
Lookup resource names in additional answer segment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,7 @@
 Changelog
 ---------
+Next Release
+  * Look up SRV names in DNS additional records segment
+
 2014-03-11: v0.1.0
   * Initial version

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,13 @@ Example
      SRV(host='192.168.1.126', port=11211, priority=1, weight=0)]
     >>>
 
+Testing
+-------
+.. code:: bash
+    
+    python setup.py nosetests
+
+
 Requirements
 ------------
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,11 @@ tests_require = ['nose', 'mock']
 if sys.version_info < (2, 7, 0):
     tests_require.append('unittest2')
 
-dnspython = 'dnspython' if sys.version_info < (3, 0, 0) else 'dnspython3'
+requirements = []
+if sys.version_info < (3, 0, 0):
+    requirements.append('dnspython>=1.12.0,<2.0')
+else:
+    requirements.append('dnspython3>=1.12.0,<2.0')
 
 setuptools.setup(name='srvlookup',
                  version='0.1.0',
@@ -17,7 +21,7 @@ setuptools.setup(name='srvlookup',
                  py_modules=['srvlookup'],
                  package_data={'': ['LICENSE', 'README.rst']},
                  include_package_data=True,
-                 install_requires=[dnspython],
+                 install_requires=requirements,
                  tests_require=tests_require,
                  test_suite='nose.collector',
                  license=open('LICENSE').read(),

--- a/tests.py
+++ b/tests.py
@@ -18,22 +18,21 @@ class WhenRaisingException(unittest.TestCase):
 
 class WhenLookingUpRecords(unittest.TestCase):
 
-    MESSAGE = """\
-id 1234
-opcode QUERY
-rcode NOERROR
-flags QR AA RD
-;QUESTION
-foo.bar.baz. IN SRV
-;ANSWER
-foo.bar.baz. 0    IN  SRV 2 0 11211 1.2.3.4.
-foo.bar.baz. 0    IN  SRV 1 0 11211 1.2.3.5.
-"""
+    def get_message(self):
+        message_body = [
+            'id 1234', 'opcode QUERY', 'rcode NOERROR', 'flags QR AA RD',
+            ';QUESTION',
+            'foo.bar.baz. IN SRV',
+            ';ANSWER',
+            'foo.bar.baz. 0 IN SRV 2 0 11211 1.2.3.4.',
+            'foo.bar.baz. 0 IN SRV 1 0 11211 1.2.3.5.',
+        ]
+        return message.from_text('\n'.join(message_body))
 
     def test_should_return_a_list_of_records(self):
         with mock.patch('dns.resolver.query') as query:
             query_name = name.from_text('foo.bar.baz.')
-            msg = message.from_text(self.MESSAGE)
+            msg = self.get_message()
             answer = resolver.Answer(query_name,
                                      33, 1, msg,
                                      msg.answer[0])
@@ -48,7 +47,7 @@ foo.bar.baz. 0    IN  SRV 1 0 11211 1.2.3.5.
             with mock.patch('socket.getfqdn') as getfqdn:
                 getfqdn.return_value = 'baz'
                 query_name = name.from_text('foo.bar.baz.')
-                msg = message.from_text(self.MESSAGE)
+                msg = self.get_message()
                 answer = resolver.Answer(query_name,
                                          33, 1, msg,
                                          msg.answer[0])


### PR DESCRIPTION
This PR looks up the name from each answer in the additional records segment and returns any address records that it finds there.  If the name does not appear in the additional records, then it is returned as-is (which was the previous behavior).
