### PR TITLE
Sort by weight according to RFC2782

### DIFF
--- a/srvlookup.py
+++ b/srvlookup.py
@@ -121,6 +121,9 @@ def _build_result_set(answer):
                     resource.priority, resource.weight)
                 for address in resource_map[target])
         else:
-            result_set.append(SRV(target.rstrip('.'), resource.port,
-                                  resource.priority, resource.weight))
+            result_set.append(SRV(
+                target.decode('utf8').rstrip('.'),
+                resource.port,
+                resource.priority,
+                resource.weight))
     return result_set

--- a/srvlookup.py
+++ b/srvlookup.py
@@ -50,7 +50,7 @@ def lookup(name, protocol='TCP', domain=None):
     answer = _query_srv_records('_%s._%s.%s' % (name, protocol,
                                                 domain or _get_domain()))
     results = _build_result_set(answer)
-    return sorted(results, key=lambda r: r.priority)
+    return sorted(results, key=lambda r: (r.priority, -r.weight, r.host))
 
 
 def _get_domain():

--- a/tests.py
+++ b/tests.py
@@ -62,6 +62,21 @@ class WhenLookingUpRecords(unittest.TestCase):
                                  [srvlookup.SRV('1.2.3.5', 11212, 1, 0),
                                   srvlookup.SRV('1.2.3.4', 11211, 2, 0)])
 
+    def test_should_sort_records_by_priority_weight_and_host(self):
+
+        with mock.patch('dns.resolver.query') as query:
+                query_name = name.from_text('foo.bar.baz.')
+                msg = self.get_message(additional_answers=[
+                    'foo.bar.baz. 0 IN SRV 0 0 11213 foo3.bar.baz.'])
+                answer = resolver.Answer(query_name,
+                                         33, 1, msg,
+                                         msg.answer[0])
+                query.return_value = answer
+                self.assertEqual(srvlookup.lookup('foo', 'bar'),
+                                 [srvlookup.SRV('foo3.bar.baz', 11213, 0, 0),
+                                  srvlookup.SRV('1.2.3.5', 11212, 1, 0),
+                                  srvlookup.SRV('1.2.3.4', 11211, 2, 0)])
+
     def test_should_return_name_when_addt_record_is_missing(self):
         with mock.patch('dns.resolver.query') as query:
             query_name = name.from_text('foo.bar.baz.')


### PR DESCRIPTION
Also fixes a bug related to the use of rstrip(). Tests pass against Python2.7 and Python3.5.