### PR TITLE
Preserve hostnames in the SRV tuple

### DIFF
--- a/srvlookup.py
+++ b/srvlookup.py
@@ -14,7 +14,7 @@ __version__ = '1.0.0'
 
 LOGGER = logging.getLogger(__name__)
 
-SRV = namedtuple('SRV', ['host', 'port', 'priority', 'weight'])
+SRV = namedtuple('SRV', ['host', 'port', 'priority', 'weight', 'hostname'])
 
 
 class SRVQueryFailure(Exception):
@@ -34,10 +34,10 @@ def lookup(name, protocol='TCP', domain=None):
 
         >>> import srvlookup
         >>> srvlookup.lookup('api', 'memcached')
-        [SRV(host='192.169.1.100', port=11211, priority=1, weight=0),
-         SRV(host='192.168.1.102', port=11211, priority=1, weight=0),
-         SRV(host='192.168.1.120', port=11211, priority=1, weight=0),
-         SRV(host='192.168.1.126', port=11211, priority=1, weight=0)]
+        [SRV(host='192.169.1.100', port=11211, priority=1, weight=0, hostname='host1.example.com'),
+         SRV(host='192.168.1.102', port=11211, priority=1, weight=0, hostname='host2.example.com'),
+         SRV(host='192.168.1.120', port=11211, priority=1, weight=0, hostname='host3.example.com'),
+         SRV(host='192.168.1.126', port=11211, priority=1, weight=0, hostname='host4.example.com')]
         >>>
 
     :param str name: The service name
@@ -116,10 +116,10 @@ def _build_result_set(answer):
         target = resource.target.to_text()
         if target in resource_map:
             result_set.extend(
-                SRV(address, resource.port, resource.priority, resource.weight)
+                SRV(address, resource.port, resource.priority, resource.weight, target.strip('.'))
                 for address in resource_map[target])
         else:
             result_set.append(
                 SRV(target.rstrip('.'), resource.port, resource.priority,
-                    resource.weight))
+                    resource.weight, target.strip('.')))
     return result_set

--- a/tests.py
+++ b/tests.py
@@ -44,8 +44,8 @@ class WhenLookingUpRecords(unittest.TestCase):
                                      msg.answer[0])
             query.return_value = answer
             self.assertEqual(srvlookup.lookup('foo', 'bar', 'baz'),
-                             [srvlookup.SRV('1.2.3.5', 11212, 1, 0),
-                              srvlookup.SRV('1.2.3.4', 11211, 2, 0)])
+                             [srvlookup.SRV('1.2.3.5', 11212, 1, 0, 'foo2.bar.baz'),
+                              srvlookup.SRV('1.2.3.4', 11211, 2, 0, 'foo1.bar.baz')])
 
     def test_should_include_local_domain_when_omitted(self):
 
@@ -59,8 +59,8 @@ class WhenLookingUpRecords(unittest.TestCase):
                                          msg.answer[0])
                 query.return_value = answer
                 self.assertEqual(srvlookup.lookup('foo', 'bar'),
-                                 [srvlookup.SRV('1.2.3.5', 11212, 1, 0),
-                                  srvlookup.SRV('1.2.3.4', 11211, 2, 0)])
+                                 [srvlookup.SRV('1.2.3.5', 11212, 1, 0, 'foo2.bar.baz'),
+                                  srvlookup.SRV('1.2.3.4', 11211, 2, 0, 'foo1.bar.baz')])
 
     def test_should_sort_records_by_priority_weight_and_host(self):
 
@@ -73,9 +73,9 @@ class WhenLookingUpRecords(unittest.TestCase):
                                          msg.answer[0])
                 query.return_value = answer
                 self.assertEqual(srvlookup.lookup('foo', 'bar'),
-                                 [srvlookup.SRV('foo3.bar.baz', 11213, 0, 0),
-                                  srvlookup.SRV('1.2.3.5', 11212, 1, 0),
-                                  srvlookup.SRV('1.2.3.4', 11211, 2, 0)])
+                                 [srvlookup.SRV('foo3.bar.baz', 11213, 0, 0, 'foo3.bar.baz'),
+                                  srvlookup.SRV('1.2.3.5', 11212, 1, 0, 'foo2.bar.baz'),
+                                  srvlookup.SRV('1.2.3.4', 11211, 2, 0, 'foo1.bar.baz')])
 
     def test_should_return_name_when_addt_record_is_missing(self):
         with mock.patch('dns.resolver.query') as query:
@@ -87,9 +87,9 @@ class WhenLookingUpRecords(unittest.TestCase):
                                      msg.answer[0])
             query.return_value = answer
             self.assertEqual(srvlookup.lookup('foo', 'bar', 'baz'),
-                             [srvlookup.SRV('1.2.3.5', 11212, 1, 0),
-                              srvlookup.SRV('1.2.3.4', 11211, 2, 0),
-                              srvlookup.SRV('foo3.bar.baz', 11213, 3, 0)])
+                             [srvlookup.SRV('1.2.3.5', 11212, 1, 0, 'foo2.bar.baz'),
+                              srvlookup.SRV('1.2.3.4', 11211, 2, 0, 'foo1.bar.baz'),
+                              srvlookup.SRV('foo3.bar.baz', 11213, 3, 0, 'foo3.bar.baz')])
 
 
 class WhenInvokingGetDomain(unittest.TestCase):


### PR DESCRIPTION
When the SRV records refer to TLS-protected services, always knowing
the name of the service (as present in the SRV RR) is important so as to
properly verify the connection.
This commit modifies the tuple structure to add a hostname field (in
addition to the host field) which contains the original hostname from
the RR.

Where the name to IP mapping fails (perhaps because the name isn't
resolvable), the SRV tuple will contain the same value in both the host
and hostname fields).

The hostname field is added to the end of the tuple to minimise backward
compatibility issues.

Fixes gmr/srvlookup#4 