### PR TITLE
Use protocol TCP for DNS lookups

### DIFF
--- a/srvlookup.py
+++ b/srvlookup.py
@@ -78,7 +78,7 @@ def _query_srv_records(fqdn):
 
     """
     try:
-        return resolver.query(fqdn, 'SRV')
+        return resolver.query(fqdn, 'SRV', tcp=True)
     except (resolver.NoAnswer, resolver.NoNameservers, resolver.NotAbsolute,
             resolver.NoRootSOA, resolver.NXDOMAIN) as error:
         LOGGER.error('Error querying SRV for %s: %r', fqdn, error)

--- a/tests.py
+++ b/tests.py
@@ -116,7 +116,7 @@ class WhenInvokingQuerySRVRecords(unittest.TestCase):
             query.return_value = mock.Mock('dns.resolver.Answer')
             fqdn = 'foo.bar.baz'
             srvlookup._query_srv_records(fqdn)
-            query.assert_called_once_with(fqdn, 'SRV')
+            query.assert_called_once_with(fqdn, 'SRV', tcp=True)
 
     def test_should_return_resolver_answer(self):
         with mock.patch('dns.resolver.query') as query:


### PR DESCRIPTION
The default protocol used is UDP and there is a limit in the response sizes for it.
Using TCP any response size is OK.

Linked to this issue: https://github.com/gmr/srvlookup/issues/6