### PR TITLE
Deprecate query

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     py_modules=['srvlookup'],
     package_data={'': ['LICENSE', 'README.rst']},
     include_package_data=True,
-    install_requires=['dnspython>=1.15.0'],
+    install_requires=['dnspython>=2.0.0'],
     tests_require=['nose', 'mock', 'coverage'],
     test_suite='nose.collector',
     license='BSD',

--- a/srvlookup.py
+++ b/srvlookup.py
@@ -78,7 +78,7 @@ def _query_srv_records(fqdn):
 
     """
     try:
-        return resolver.query(fqdn, 'SRV')
+        return resolver.resolve(fqdn, 'SRV')
     except (resolver.NoAnswer, resolver.NoNameservers, resolver.NotAbsolute,
             resolver.NoRootSOA, resolver.NXDOMAIN) as error:
         LOGGER.error('Error querying SRV for %s: %r', fqdn, error)


### PR DESCRIPTION
When using this library, it showing this message:

```
srvlookup.py:81: DeprecationWarning: please use dns.resolver.resolve() instead
    return resolver.query(fqdn, 'SRV')
```
What about update on new version dnspython (>2.0.0)