### PR TITLE
adds a method to return expiration of the records

### DIFF
--- a/srvlookup/__init__.py
+++ b/srvlookup/__init__.py
@@ -2,7 +2,7 @@
 Service lookup using DNS SRV records
 
 """
-from .main import lookup, SRV, SRVQueryFailure
+from .main import lookup, lookup_expiry, SRV, SRVQueryFailure
 
 __all__ = [
     'lookup', 'SRV', 'SRVQueryFailure'


### PR DESCRIPTION
This adds a `lookup_expiry` helper method that will return the validity period of the records that were just returned.

This is convenient when the consumer of srvlookup is a long running process. The records should only be considered authoritative until their expiration.